### PR TITLE
Remove unnecessary dependencies and move the others to peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,6 @@
     "@frontity/tiny-router": "^1.0.14",
     "@frontity/wp-source": "^1.3.1",
     "frontity": "^1.3.1",
-	"contact-form-7": "./packages/contact-form-7"
+    "contact-form-7": "./packages/contact-form-7"
   }
 }

--- a/packages/contact-form-7/package.json
+++ b/packages/contact-form-7/package.json
@@ -3,9 +3,6 @@
   "version": "0.1.1",
   "description": "Contact Form 7 extension for Frontity theme.",
   "main": "src/index.js",
-  "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
-  },
   "homepage": "https://codeytek.com",
   "keywords": [
     "Frontity",
@@ -13,28 +10,25 @@
     "form",
     "7",
     "cf7",
-	"WordPress",
-	"Reactjs",
-	"react"
+    "WordPress",
+    "Reactjs",
+    "react",
+    "frontity-cf7"
   ],
   "author": "Imran Sayed, Smit Patadiya",
   "license": "GNU GPL 2",
   "repository": {
-	"type": "git",
-	"url": "https://github.com/imranhsayed/frontity-contact-form-7"
+    "type": "git",
+    "url": "https://github.com/imranhsayed/frontity-contact-form-7"
   },
   "bugs": {
-	"url": "https://community.frontity.org"
+    "url": "https://community.frontity.org"
   },
   "publishConfig": {
-	"access": "public"
+    "access": "public"
   },
-  "dependencies": {
-	"@frontity/core": "^1.2.1",
-	"@frontity/html2react": "^1.1.11",
-	"@frontity/mars-theme": "^1.2.0",
-	"@frontity/tiny-router": "^1.0.14",
-	"@frontity/wp-source": "^1.3.1",
-	"frontity": "^1.3.1"
+  "peerDependencies": {
+    "frontity": "^1.3.1",
+    "@frontity/html2react": "^1.1.11"
   }
 }


### PR DESCRIPTION
Hey guys. I'm sorry I didn't tell you this before, but we are moving the root dependencies of Frontity packages to `peerDependencies` to solve a problem with npm messing up the versions and ending up with two `@frontity/connect` packages.

This problem actually: https://github.com/imranhsayed/frontity-twentynineteen/pull/22#issuecomment-534501592

So could you please merge this PR and republish the package? Thanks! :)