### PR TITLE
Simplify install instructions in Readme

### DIFF
--- a/packages/contact-form-7/README.md
+++ b/packages/contact-form-7/README.md
@@ -1,80 +1,50 @@
-# Frontity Contact Form 7 Project :art:
+# Frontity Contact Form 7 :art:
 
-:fire: Contact Form 7 extension for Frontity theme.
+:fire: Contact Form 7 package for Frontity.
 
 # How does it work?
 
-> You need to create a page in your WordPress site ( if you don't already have one ) that contains the CF7 shortcode.
-Install the package as shown in the Installation steps below.
->Then put that WordPress page name, the slug and the package name in the `frontity-settings.js` as explained below. The Frontity page will automatically render all the CF7
-forms that are present on that page including the content of the page.
-On successful form submission, the email goes to the admin ( if CF7 email settings are configured on your WordPress site  ). Errors are shown as well if the fields are invalid.
+1. You need to create a page in your WordPress site (if you don't already have one) that contains a CF7 shortcode.
+1. Install the Frontity Contact Form 7 package as shown in the Installation steps below.
+1. Visit that page in Frontity and the package will automatically render all the CF7
+   forms that are present, including other content on the page.
+1. On successful form submission, the email goes to the admin (if CF7 email settings are configured on your WordPress site). Errors are shown as well if the fields are invalid.
 
 > It uses html processors to render the CF7 form.
 
 # Features
-1. All CF7 forms on the page will display
-2. You can also use it for multiple pages.
-3. Built with React Frontity in React, so its fast and performant.
 
+1. All the CF7 forms on the page will work.
+2. You can also use it for multiple pages.
+3. Built with React and Frontity, so its fast and performant.
 
 # Installation :wrench:
 
-### 1. For new project: by cloning this project.
+1. Do `npm install frontity-contact-form-7` in the root of your project.
+1. Add the package name in `frontity-settings.js`.
 
-1. `git clone https://github.com/imranhsayed/frontity-contact-form-7`
-2. `cd frontity-contact-form-7`
-3. `npm install && npx frontity dev` ( from the project's root directory )
- 
-4. Your site will now be available at `http://localhost:3000/`
-
-## 2. For new/existing project using npm
-
-> Please follow step 1 to 5 for new project and 2 to 5 for existing project.
-
-1. `npx frontity create my-app && cd my-app`
-2. `npm install frontity-contact-form-7` ( in the root of your project )
-3. In the `frontity-settings.js`
-a. Add the package name
-```ruby
-  "packages": [
-    {
-      "frontity-contact-form-7",
+```javascript
+"packages": [
+  "frontity-contact-form-7"
+  // other packages ...
+]
 ```
-b. Add Contact form 7 page name and slug as what you have on your WordPress site. For example
-```ruby
-        "theme": {
-          "menu": [
-            [
-              "Contact Form 7",
-              "/cf7"
-            ],
-```
-c. Update your WordPress API URI if not added already.
- ```ruby
-      "state": {
-        "source": {
-          "api": "https://your-wordpress-site.com/wp-json"
-        }
- ```
-4. `npx frontity dev` ( from project's root directory )
-5. Your site will be available at `http://localhost:3000/`
+
+3. Run `npx frontity dev` again.
+
+That's it! The package doesn't need any settings. You should be able to see the form in any page or post that contains one.
 
 ## More info :clipboard:
 
 This is the beta version. Some features will be added in the final release, like:
 
-1. More button smaller screens.
-
-## Common Commands :computer:
-
-- `npx frontity dev` ( inside project's root ) Runs server in development mode ( from the root of your project )
+1. [Support for all the fields](https://github.com/imranhsayed/frontity-contact-form-7/issues/8).
 
 ## Credits :white_flower:
 
 - Build with love :blue_heart:, using [Frontity's](https://frontity.org)
 
-## Author
+## Authors
 
 1. [Imran Sayed](https://twitter.com/imranhsayed)
 2. [Smit Patadiya](https://twitter.com/smit_patadiya)


### PR DESCRIPTION
Hey guys, I've simplified the installation instructions in the Readme, as this is always going to be a package installed in `node_modules`.

Feel free to merge and congratulations on the amazing work :)