### PR TITLE
Fix issue with cf7 v5.2

### DIFF
--- a/packages/contact-form-7/src/processors/cf7Form.js
+++ b/packages/contact-form-7/src/processors/cf7Form.js
@@ -4,7 +4,7 @@ const cf7Form = {
 	name: "cf7Form",
 	test: ({ node }) =>
 
-		node.component === "form" && node.props.className === "wpcf7-form",
+		node.component === "form" && /wpcf7-form/.test( node.props.className ),
 
 	processor: ({ node }) => {
 


### PR DESCRIPTION
This PR fixes the issue with the latest update of cf7(v5.2). In the latest version class name for the form is updated causing  an internal server error(`TypeError: Cannot read property 'inputVals' of undefined`) when contact page is accessed. Tested the change with older versions also.